### PR TITLE
Hdf5 cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FRASER
 Type: Package
 Title: Find RAre Splicing Events in RNA-Seq Data
-Version: 2.4.2
-Date: 2025-05-11
+Version: 2.4.3
+Date: 2025-06-04
 Authors@R: c(
     person("Christian", "Mertes", role=c("aut", "cre"), 
             email="mertes@in.tum.de", comment=c(ORCID="0000-0002-1091-205X")),

--- a/R/calculatePSIValue.R
+++ b/R/calculatePSIValue.R
@@ -126,6 +126,7 @@ calculatePSIValuePrimeSite <- function(fds, psiType, overwriteCts, BPPARAM){
             }
             
             # write other counts and psi values to h5 file
+	    if (file.exists(cacheFile)) file.remove(cacheFile)
             # get defined chunk sizes
             chunkDims <- c(
                 min(nrow(countData), options()[['FRASER-hdf5-chunk-nrow']]),


### PR DESCRIPTION
- Remove hdf5 cache objects if existing before writing psi hdf5 files
- Update to V 2.4.3